### PR TITLE
Updated Google Generative AI model to Gemini 2.5 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ flask run
 
 Navigate to http://127.0.0.1:5000/ in your browser and you should be live!
 
+Hosted website: https://call-for-meal.onrender.com/
+
 ## 🚀 What's Next? (Future Ideas)
 
 This was an amazing hackathon build, but we're just getting started. Here's where we could take NourishAI next:


### PR DESCRIPTION
Google Generative AI model gemini 1.5 flash seems to be unsupported by the SDK, switching to gemini 2.5 flash in routes.py.